### PR TITLE
Feat: [#13] 스프링 부트 메모리 제한

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,4 +14,4 @@ ARG SPRING_ACTIVE_PROFILE=dev
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
-ENTRYPOINT ["java","-jar","/app.jar","--spring.profiles.active=","${SPRING_ACTIVE_PROFILE}"]
+ENTRYPOINT ["java","-XX:+UseSerialGC","-Xss1M","-Xms220m","-Xmx220m","-jar","/app.jar","--spring.profiles.active=","${SPRING_ACTIVE_PROFILE}"]

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,6 +2,12 @@ spring:
   profiles:
     default: prod
 
+# Default Tomcat Thread Max 200 count -> 4
+server:
+  tomcat:
+    threads:
+      max: 4
+
 ---
 spring:
   config:


### PR DESCRIPTION
## 🤔 PR 생성한 이유가 무엇인가요?

- 서버 사양으로 인한 스프링 부트 메모리 제한
- 자세한 내용은 정리한 문서 참고(👉 [스프링 부트 메모리 감량 방법](https://www.notion.so/e70a02fa59e540878965f36fac503aa3?p=c7e5cf7f65204795af651eeacffcd019&pm=s))

<br>

## 🔍 어떤 부분이 변경되었나요?

- jar 실행 시 스택, 힙 메모리 제한
- 톰켓 MAX 스레드 4로 제한
- G1 GC -> SerialGC로 변경