### PR TITLE
Feat: [#60] 비밀번호 변경 시 인증문자 전송 기능 추가

### DIFF
--- a/src/docs/asciidoc/account.adoc
+++ b/src/docs/asciidoc/account.adoc
@@ -16,14 +16,16 @@ operation::account-controller-test/sign-up-test[snippets='http-request,request-f
 === 로그인 요청
 operation::account-controller-test/login-test[snippets='http-request,request-fields,http-response,response-fields']
 
-=== 이메일 찾기
-operation::account-controller-test/find-member-by-email-test[snippets='http-request,request-parameters,response-body,response-fields']
+=== 인증문자 전송
+operation::account-controller-test/send-auth-code-test[snippets='http-request,request-fields']
+
+=== 비밀번호 변경 시 인증문자 요청
+패스워드를 분실하여 이메일 인증 시 사용한다.
+
+operation::account-controller-test/email-certification-test[snippets='http-request,request-fields,response-body,response-fields']
 
 === 인증번호 업데이트
 operation::account-controller-test/update-access-code-test[snippets='http-request,request-fields']
 
 === 비밀번호 변경
 operation::account-controller-test/update-password-test[snippets='http-request,request-fields']
-
-=== 인증문자 전송
-operation::account-controller-test/send-auth-code-test[snippets='http-request,request-fields']

--- a/src/main/java/com/litarary/account/domain/entity/Member.java
+++ b/src/main/java/com/litarary/account/domain/entity/Member.java
@@ -37,7 +37,7 @@ public class Member {
     private String password;
 
     @Column
-    private String accessCode;
+    private String authCode;
 
     @Column(nullable = false)
     private boolean isServiceTerms;
@@ -66,13 +66,13 @@ public class Member {
         this.refreshToken = token;
     }
 
-    public void validAccessCode(String accessCode) {
-        if (!accessCode.equals(this.accessCode)) {
-            throw new LitararyErrorException(ErrorCode.ACCOUNT_ACCESS_ROLE_MISS_MATCH);
+    public void validAuthCode(String accessCode) {
+        if (!accessCode.equals(this.authCode)) {
+            throw new LitararyErrorException(ErrorCode.MISS_MATCH_AUTH_CODE);
         }
     }
 
-    public void updateAccessCode(String accessCode) {
-        this.accessCode = accessCode;
+    public void updateAuthCode(String authCode) {
+        this.authCode = authCode;
     }
 }

--- a/src/main/java/com/litarary/account/service/mail/GmailSenderServiceImpl.java
+++ b/src/main/java/com/litarary/account/service/mail/GmailSenderServiceImpl.java
@@ -20,13 +20,13 @@ public class GmailSenderServiceImpl implements MailSenderService {
     private final JavaMailSender gmailSender;
 
     @Override
-    public void sendAuthCode(String email) {
+    public String sendAuthCode(String email) {
 
         MimeMessage mimeMessage = gmailSender.createMimeMessage();
-        sendMessage(email, mimeMessage);
+        return sendMessage(email, mimeMessage);
     }
 
-    private void sendMessage(String email, MimeMessage mimeMessage) {
+    private String sendMessage(String email, MimeMessage mimeMessage) {
         try {
             String authCode = AuthCodeGenerator.generateCode();
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
@@ -35,6 +35,7 @@ public class GmailSenderServiceImpl implements MailSenderService {
             String message = String.format("안녕하세요! Litarary에 방문해주셔서 감사합니다. \n 이메일 인증문자 입니다. 확인 후 가입 부탁드립니다. \n\n 인증문자 : %s", authCode);
             mimeMessageHelper.setText(message);
             gmailSender.send(mimeMessage);
+            return authCode;
         } catch (MessagingException ex) {
             log.warn("Gmail message error : {}", ex.getMessage());
             throw new LitararyErrorException(ErrorCode.GMAIL_SENDER_ERROR, ex.getMessage());

--- a/src/main/java/com/litarary/account/service/mail/MailSenderService.java
+++ b/src/main/java/com/litarary/account/service/mail/MailSenderService.java
@@ -2,5 +2,5 @@ package com.litarary.account.service.mail;
 
 public interface MailSenderService {
 
-    void sendAuthCode(String email);
+    String sendAuthCode(String email);
 }

--- a/src/main/java/com/litarary/common/ErrorCode.java
+++ b/src/main/java/com/litarary/common/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND("등록된 회원이 없습니다."),
     MISS_MATCH_PASSWORD("비밀번호가 일치하지 않습니다."),
     GMAIL_SENDER_ERROR("SMTP 이메일 전송에 실패했습니다."),
+    MISS_MATCH_AUTH_CODE("인증문자가 일치하지 않습니다."),
 
     //JWT Error
     EXPIRED_TOKEN("만료된 토큰입니다."),
@@ -27,7 +28,7 @@ public enum ErrorCode {
 
     // Book Error
     JSON_PARSING_ERROR("Json Parse에 실패했습니다."),
-    EXTERNAL_REQUEST_ERROR("외부 API요청에 실패했습니다.")
-    ;
+    EXTERNAL_REQUEST_ERROR("외부 API요청에 실패했습니다.");
+
     private final String message;
 }

--- a/src/main/resources/static/docs/account.html
+++ b/src/main/resources/static/docs/account.html
@@ -447,10 +447,10 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_회원_가입_요청">회원 가입 요청</a></li>
 <li><a href="#_로그인_요청">로그인 요청</a></li>
-<li><a href="#_이메일_찾기">이메일 찾기</a></li>
+<li><a href="#_인증문자_전송">인증문자 전송</a></li>
+<li><a href="#_비밀번호_변경_시_인증문자_요청">비밀번호 변경 시 인증문자 요청</a></li>
 <li><a href="#_인증번호_업데이트">인증번호 업데이트</a></li>
 <li><a href="#_비밀번호_변경">비밀번호 변경</a></li>
-<li><a href="#_인증문자_전송">인증문자 전송</a></li>
 </ul>
 </li>
 </ul>
@@ -623,7 +623,7 @@ Content-Length: 523
   "accessToken" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
   "refreshToken" : "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
   "grantType" : "Bearer",
-  "expiredAccessTokenAt" : "2023-03-18T17:26:06.714605"
+  "expiredAccessTokenAt" : "2023-03-18T23:39:11.797576"
 }</code></pre>
 </div>
 </div>
@@ -684,40 +684,93 @@ Content-Length: 523
 </div>
 </div>
 <div class="sect2">
-<h3 id="_이메일_찾기"><a class="link" href="#_이메일_찾기">이메일 찾기</a></h3>
+<h3 id="_인증문자_전송"><a class="link" href="#_인증문자_전송">인증문자 전송</a></h3>
 <div class="sect3">
-<h4 id="_이메일_찾기_http_request"><a class="link" href="#_이메일_찾기_http_request">HTTP request</a></h4>
+<h4 id="_인증문자_전송_http_request"><a class="link" href="#_인증문자_전송_http_request">HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/v1/account?email=test%40test.com HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/account/send-code HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Host: localhost:8080</code></pre>
+Content-Length: 32
+Host: localhost:8080
+
+{
+  "email" : "test@gmail.com"
+}</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_이메일_찾기_request_parameters"><a class="link" href="#_이메일_찾기_request_parameters">Request parameters</a></h4>
+<h4 id="_인증문자_전송_request_fields"><a class="link" href="#_인증문자_전송_request_fields">Request fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
 <th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인증문자 전송할 메일주소</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_비밀번호_변경_시_인증문자_요청"><a class="link" href="#_비밀번호_변경_시_인증문자_요청">비밀번호 변경 시 인증문자 요청</a></h3>
+<div class="paragraph">
+<p>패스워드를 분실하여 이메일 인증 시 사용한다.</p>
+</div>
+<div class="sect3">
+<h4 id="_비밀번호_변경_시_인증문자_요청_http_request"><a class="link" href="#_비밀번호_변경_시_인증문자_요청_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">PATCH /api/v1/account/password/send-code HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 31
+Host: localhost:8080
+
+{
+  "email" : "test@test.com"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_비밀번호_변경_시_인증문자_요청_request_fields"><a class="link" href="#_비밀번호_변경_시_인증문자_요청_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_이메일_찾기_response_body"><a class="link" href="#_이메일_찾기_response_body">Response body</a></h4>
+<h4 id="_비밀번호_변경_시_인증문자_요청_response_body"><a class="link" href="#_비밀번호_변경_시_인증문자_요청_response_body">Response body</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
@@ -729,7 +782,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_이메일_찾기_response_fields"><a class="link" href="#_이메일_찾기_response_fields">Response fields</a></h4>
+<h4 id="_비밀번호_변경_시_인증문자_요청_response_fields"><a class="link" href="#_비밀번호_변경_시_인증문자_요청_response_fields">Response fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -865,55 +918,13 @@ Host: localhost:8080
 </table>
 </div>
 </div>
-<div class="sect2">
-<h3 id="_인증문자_전송"><a class="link" href="#_인증문자_전송">인증문자 전송</a></h3>
-<div class="sect3">
-<h4 id="_인증문자_전송_http_request"><a class="link" href="#_인증문자_전송_http_request">HTTP request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/v1/account/send-code HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Content-Length: 32
-Host: localhost:8080
-
-{
-  "email" : "test@gmail.com"
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_인증문자_전송_request_fields"><a class="link" href="#_인증문자_전송_request_fields">Request fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">인증문자 전송할 메일주소</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-03-18 17:14:58 +0900
+Last updated 2023-03-18 23:39:03 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/litarary/account/domain/AuthCodeGeneratorTest.java
+++ b/src/test/java/com/litarary/account/domain/AuthCodeGeneratorTest.java
@@ -17,6 +17,6 @@ class AuthCodeGeneratorTest {
         String code = AuthCodeGenerator.generateCode();
 
         assertThat(code).matches(".*\\d.*");
-        assertThat(code).matches("[A-Z].*");
+        assertThat(code).matches(".*[A-Z].*");
     }
 }


### PR DESCRIPTION
## 🤔 PR 생성한 이유가 무엇인가요?

- 비밀번호 변경 시 인증문자를 이메일로 전송하는 기능추가
- 회원가입 시 이메일 인증할때 사용하는 API랑 가입 전후가 달라 동일 API를 사용할 수 없음.

<br>

## 🔍 어떤 부분이 변경되었나요?

- 이전에 만들어둔 이메일 찾기 API 대신 이메일로 인증문자 전송하는 기능으로 변경
- Rest Docs수정
- 메일로 인증문자 전송기능 추가

closed #60 