### PR TITLE
Feat: [#68] 회원가입 반복 시도 시 오류 수정

### DIFF
--- a/src/main/java/com/litarary/account/controller/AccountController.java
+++ b/src/main/java/com/litarary/account/controller/AccountController.java
@@ -42,7 +42,7 @@ public class AccountController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @PatchMapping("/password/send-code")
+    @PostMapping("/password/send-code")
     public MemberEmailDto.Response emailCertification(@Valid @RequestBody MemberEmailDto.Request request) {
         Member member = accountService.findMember(request.getEmail(), UseYn.Y);
         String authCode = authCodeGenerator.generateCode();
@@ -52,7 +52,7 @@ public class AccountController {
     }
 
     @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/check-auth-code")
+    @PostMapping("/check-auth-code")
     public void checkAuthCode(@Valid @RequestBody MemberAccessCode.Request request) {
         accountService.checkAuthCode(request.getMemberId(), request.getAuthCode());
     }

--- a/src/main/java/com/litarary/account/controller/dto/MemberAccessCode.java
+++ b/src/main/java/com/litarary/account/controller/dto/MemberAccessCode.java
@@ -1,9 +1,6 @@
 package com.litarary.account.controller.dto;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -13,6 +10,8 @@ import javax.validation.constraints.NotBlank;
 public class MemberAccessCode {
 
     @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
     @Getter
     public static class Request {
 

--- a/src/main/java/com/litarary/account/controller/dto/MemberDto.java
+++ b/src/main/java/com/litarary/account/controller/dto/MemberDto.java
@@ -2,10 +2,7 @@ package com.litarary.account.controller.dto;
 
 import com.litarary.account.domain.AccessRole;
 import com.litarary.account.domain.BookCategory;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.*;
 import java.util.List;
@@ -15,6 +12,8 @@ import java.util.List;
 public class MemberDto {
 
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Getter
     public static class Request {
 

--- a/src/main/java/com/litarary/account/repository/AccountRepository.java
+++ b/src/main/java/com/litarary/account/repository/AccountRepository.java
@@ -13,4 +13,6 @@ public interface AccountRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndUseYn(String email, UseYn useYn);
 
     boolean existsByEmailAndUseYn(String email, UseYn useYn);
+
+    Member findByEmail(String email);
 }

--- a/src/main/java/com/litarary/account/service/AccountService.java
+++ b/src/main/java/com/litarary/account/service/AccountService.java
@@ -121,6 +121,15 @@ public class AccountService {
     }
 
     public MemberDefaultInfo createMember(String email, String authCode) {
+        Member findMember = accountRepository.findByEmail(email);
+        if (findMember != null) {
+            findMember.updateAuthCode(authCode);
+            return MemberDefaultInfo.builder()
+                    .memberId(findMember.getId())
+                    .email(findMember.getEmail())
+                    .build();
+        }
+
         Member member = Member.builder()
                 .email(email)
                 .authCode(authCode)
@@ -129,6 +138,7 @@ public class AccountService {
                 .useYn(UseYn.N)
                 .build();
 
+        accountRepository.findByEmail(email);
         Member savedMember = accountRepository.save(member);
         return MemberDefaultInfo.builder()
                 .memberId(savedMember.getId())

--- a/src/main/java/com/litarary/book/service/aladdin/AladdinBookServiceImpl.java
+++ b/src/main/java/com/litarary/book/service/aladdin/AladdinBookServiceImpl.java
@@ -29,6 +29,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.annotation.PostConstruct;
+import java.net.URI;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -102,7 +103,7 @@ public class AladdinBookServiceImpl implements BookContainerService {
     }
 
     private AladdinBookResponse requestBookInfo(AladdinBookRequest requestEntity) {
-        String uriString = createRequestUrl(this.endPointUrl, requestEntity);
+        URI uriString = createRequestUrl(this.endPointUrl, requestEntity);
         HttpEntity<AladdinBookRequest> requestHttpEntity = new HttpEntity<>(requestEntity, this.httpHeaders);
 
         try {
@@ -115,7 +116,7 @@ public class AladdinBookServiceImpl implements BookContainerService {
         }
     }
 
-    private String createRequestUrl(String endPointUrl, AladdinBookRequest requestEntity) {
+    private URI createRequestUrl(String endPointUrl, AladdinBookRequest requestEntity) {
         return UriComponentsBuilder.fromUriString(endPointUrl)
                 .queryParam("TTBKey", requestEntity.getSecretKey())
                 .queryParam("Query", requestEntity.getQuery())
@@ -126,6 +127,8 @@ public class AladdinBookServiceImpl implements BookContainerService {
                 .queryParam("Sort", requestEntity.getSort())
                 .queryParam("Output", requestEntity.getOutput())
                 .queryParam("Cover", requestEntity.getCover())
-                .toUriString();
+                .build()
+                .encode()
+                .toUri();
     }
 }

--- a/src/main/java/com/litarary/common/ErrorCode.java
+++ b/src/main/java/com/litarary/common/ErrorCode.java
@@ -28,7 +28,8 @@ public enum ErrorCode {
 
     // Book Error
     JSON_PARSING_ERROR("Json Parse에 실패했습니다."),
-    EXTERNAL_REQUEST_ERROR("외부 API요청에 실패했습니다.");
+    EXTERNAL_REQUEST_ERROR("외부 API요청에 실패했습니다."),
+    CONVERT_STRING_ENCODE_ERROR("인코딩에 실패했습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/litarary/config/Config.java
+++ b/src/main/java/com/litarary/config/Config.java
@@ -1,0 +1,27 @@
+package com.litarary.config;
+
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class Config {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = JsonMapper.builder()
+                .enable(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)
+                .build();
+        return objectMapper.registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+}

--- a/src/test/java/com/litarary/account/controller/AccountControllerTest.java
+++ b/src/test/java/com/litarary/account/controller/AccountControllerTest.java
@@ -202,7 +202,7 @@ class AccountControllerTest extends RestDocsControllerTest {
 
         String uri = REQUEST_PREFIX + "/password/send-code";
         String content = objectMapper.writeValueAsString(requestDto);
-        mockMvc.perform(patch(uri)
+        mockMvc.perform(post(uri)
                         .content(content)
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
@@ -232,7 +232,7 @@ class AccountControllerTest extends RestDocsControllerTest {
         doNothing().when(accountService).checkAuthCode(memberId, authCode);
 
         String uri = REQUEST_PREFIX + "/check-auth-code";
-        mockMvc.perform(get(uri)
+        mockMvc.perform(post(uri)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(content))
                 .andExpect(status().isOk())
@@ -335,7 +335,7 @@ class AccountControllerTest extends RestDocsControllerTest {
 
         String content = objectMapper.writeValueAsString(request);
         String uri = REQUEST_PREFIX + "/password/send-code";
-        mockMvc.perform(patch(uri)
+        mockMvc.perform(post(uri)
                         .content(content)
                         .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isBadRequest())
@@ -383,7 +383,7 @@ class AccountControllerTest extends RestDocsControllerTest {
                 .authCode("A3WRV4")
                 .build();
         String content = objectMapper.writeValueAsString(request);
-        mockMvc.perform(get("/api/v1/account/check-auth-code")
+        mockMvc.perform(post("/api/v1/account/check-auth-code")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(content))
                 .andExpect(status().isBadRequest())


### PR DESCRIPTION
## 🤔 PR 생성한 이유가 무엇인가요?

- 회원가입 인증문자를 받은 후 다시 인증문자 요청을 할 경우 에러발생하는 현상 수정

<br>

## 🔍 어떤 부분이 변경되었나요?

- 이미 이메일이 DB에 등록되어 Unique Key임으로 저장할 수 없다는 에러였음. 따라서 이메일 중복체크를 통해 이미 있는 경우 AuthCode만 업데이트 하여 반환하도록 수정함.

closed #68